### PR TITLE
docs: add DeepWiki documentation reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Better Auth adapter and plugins for Payload CMS. Enables seamless integration be
 </p>
 
 ---
+## Documentation
+For additional documentation and references, visit: [https://deepwiki.com/delmaredigital/payload-better-auth](https://deepwiki.com/delmaredigital/payload-better-auth)
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary
Added a Documentation section to README.md with a link to DeepWiki for additional reference.

## Changes
- Added new "Documentation" section before Table of Contents
- Included link to https://deepwiki.com/delmaredigital/payload-better-auth