### PR TITLE
fix(adapter): convert date strings to Date objects

### DIFF
--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -383,16 +383,19 @@ export function payloadAdapter({
                 // Keep both for compatibility - Better Auth expects userId
               }
             }
-            // Convert date strings to Date objects based on schema type
-            // Better Auth expects Date objects for expiresAt comparisons
-            if (
-              fieldDef.type === 'date' &&
-              fieldKey in transformed &&
-              typeof transformed[fieldKey] === 'string'
-            ) {
-              const dateValue = new Date(transformed[fieldKey] as string)
+          }
+
+          // Convert date strings to Date objects
+          // Better Auth expects Date objects for date field comparisons
+          for (const [key, value] of Object.entries(transformed)) {
+            if (typeof value !== 'string') continue
+
+            // Check if schema defines this field as a date type
+            const fieldDef = modelSchema.fields[key]
+            if (fieldDef?.type === 'date') {
+              const dateValue = new Date(value)
               if (!isNaN(dateValue.getTime())) {
-                transformed[fieldKey] = dateValue
+                transformed[key] = dateValue
               }
             }
           }


### PR DESCRIPTION
Payload CMS returns date fields as ISO strings, but Better Auth expects
Date objects for comparing expiresAt in session filtering logic.

This caused listSessions to return empty arrays because the comparison
`expiresAt > new Date()` failed when expiresAt was a string.

The fix checks the schema type for each field and converts string values
to Date objects when type === 'date'.