### PR TITLE
ci: add test pipeline and gate npm publish on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  # Callable so the publish pipeline can hard-gate a release on the same checks.
+  workflow_call:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  # Superseded PR pushes are cancelled; main and release runs always finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 20 is the floor declared in package.json `engines`; 24 is what the
+        # publish job builds with. Both are tested so the engines claim is real.
+        node: ['20', '24']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          # Matches the pnpm major used locally; the lockfile is v9.0 format.
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'pnpm'
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,14 @@ permissions:
   contents: write
 
 jobs:
+  # Hard gate: a tag publishes nothing unless the full CI matrix passes on the
+  # exact commit the tag points at. Reuses .github/workflows/ci.yml so the
+  # release checks can never drift from the pull-request checks.
+  ci:
+    uses: ./.github/workflows/ci.yml
+
   publish:
+    needs: ci
     runs-on: ubuntu-latest
     environment: npm
     steps:
@@ -18,7 +25,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - uses: actions/setup-node@v4
         with:
@@ -28,13 +35,13 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm test
-
+      # Tests and typecheck already ran in the `ci` job above, on this commit.
       - run: pnpm build
 
       - run: npm publish --access public
 
       - name: Create GitHub Release
-        run: gh release create ${{ github.ref_name }} --generate-notes
+        run: gh release create "$TAG" --generate-notes
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "dev-publish": "pnpm build && pnpm version prerelease --preid=dev --no-git-tag-version && pnpm publish --registry http://localhost:4873 --no-git-checks",
     "clean": "rm -rf dist",
     "generate:types": "tsx src/scripts/generate-types.ts",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## What

Adds a real CI pipeline and makes it a hard gate on publishing.

**`ci.yml`** (new) — runs `typecheck`, `test` and `build` on pull requests and pushes to `main`, across Node 20 (the `engines` floor) and Node 24 (what publish builds with).

**`publish.yml`** — now calls `ci.yml` via `workflow_call`, with the publish job declaring `needs: ci`. Pushing a `v*` tag cannot reach `npm publish` unless the full matrix passes on that exact commit.

## Why

The repo had no verification on PRs or `main` at all — every open PR showed `no checks reported`. Publishing ran a single inline `pnpm test` at tag time, which is after the tag already exists, so a failure meant an already-cut tag and a manual cleanup.

Reusing one workflow for both paths means the release checks can't drift from the PR checks.

## Incidental fixes

- CI was pinned to pnpm 9 while the lockfile is v9.0 format written by pnpm 10 — a `--frozen-lockfile` mismatch waiting to happen. Now pinned to 10.
- `gh release create` interpolated `${{ github.ref_name }}` directly into the shell command; it now goes through an env var.
- Added a `typecheck` script (`tsc --noEmit`), which had no equivalent before.

## Verification

All three steps run clean locally: typecheck exits 0, 266 tests pass across 28 files, build succeeds. Both workflow files parse as valid YAML.